### PR TITLE
Shift sensor origin down

### DIFF
--- a/ouster_description/urdf/OS1-64.urdf.xacro
+++ b/ouster_description/urdf/OS1-64.urdf.xacro
@@ -77,7 +77,7 @@
     <joint name="${name}_lidar_link_joint" type="fixed">
       <parent link="${name}" />
       <child link="${lidar_link}" />
-      <origin xyz="0.0 0.0 0.03618" rpy="0 0 0" />
+      <origin xyz="0.0 0.0 0.0" rpy="0 0 3.14159" />
     </joint>
 
     <!-- Gazebo requires the ouster_gazebo_plugins package -->


### PR DESCRIPTION
Jeff discovered that on `uomda01` that lidar data was shifted upwards. After some investigation we determined that this link having a vertical offset appears to have been the culprit.

This commit has the origin set as-on uomda01.